### PR TITLE
fix: add odom-to-tf2 pkg

### DIFF
--- a/vsss/docker/dockerfiles/vsss.dockerfile
+++ b/vsss/docker/dockerfiles/vsss.dockerfile
@@ -10,6 +10,7 @@ ENV LC_ALL=en_US.UTF-8
 RUN apt-get update && apt-get install -y --no-install-recommends \
 # TODO ----Install ros2 dependencies ----
     python3-colcon-common-extensions \
+    ros-humble-odom-to-tf-ros2 \
     && rm -rf /var/lib/apt/lists/*
 
 # Optional dev tools


### PR DESCRIPTION
Added the 'ros-humble-odom-to-tf-ros2' package to the docker container to resolve dependency issues when running the simulation.